### PR TITLE
Add Aegis specification and basic debate logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # MindMeshAI
 AI powered charting companion helping you expand upon your ideas.
+
+See [Aegis Specification](docs/AEGIS_SPEC.md) for the developer-ready PRD/FRD.
+
+## Development
+
+Install dependencies and run the API server locally:
+
+```bash
+pip install -r requirements.txt
+uvicorn app.main:app --reload
+```
+
+Run tests with:
+
+```bash
+python -m pytest
+```

--- a/app/database.py
+++ b/app/database.py
@@ -1,0 +1,19 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+
+SQLALCHEMY_DATABASE_URL = "sqlite:///./aegis.db"
+
+engine = create_engine(
+    SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}
+)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base = declarative_base()
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,133 @@
+from uuid import uuid4
+from typing import Dict, List
+
+from fastapi import FastAPI
+
+from .schemas import (
+    AuditIssue,
+    AuditRequest,
+    AuditResponse,
+    Citation,
+    LensPerspective,
+    LensRequest,
+    LensResponse,
+    NodeSchema,
+    Rebuttal,
+    RebuttalRequest,
+    RebuttalResponse,
+    ResearchRequest,
+    ResearchResponse,
+    TreeRequest,
+)
+
+app = FastAPI(title="Aegis API")
+
+
+# In-memory store for generated trees
+trees: Dict[str, NodeSchema] = {}
+
+
+def _make_citation(idx: int, topic: str) -> Citation:
+    return Citation(
+        url=f"https://example.com/{topic.replace(' ', '_')}/{idx}",
+        title=f"Source {idx}",
+        tier="B",
+        confidence=0.9,
+    )
+
+
+@app.post("/api/rebuttal", response_model=RebuttalResponse)
+async def generate_rebuttal(payload: RebuttalRequest) -> RebuttalResponse:
+    rebuttals: List[Rebuttal] = []
+    for i in range(3):
+        rebuttals.append(
+            Rebuttal(
+                summary=f"Counterpoint {i + 1} to '{payload.claim}'",
+                explanation=
+                    f"This is a generated counterargument number {i + 1} addressing '{payload.claim}'.",
+                citations=[_make_citation(i + 1, payload.claim)],
+            )
+        )
+    return RebuttalResponse(rebuttals=rebuttals)
+
+
+def _generate_counter_nodes(claim: str) -> List[NodeSchema]:
+    children: List[NodeSchema] = []
+    for i in range(3):
+        children.append(
+            NodeSchema(
+                id=str(uuid4()),
+                text=f"Counter {i + 1} to {claim}",
+                type="counter",
+                strength=50,
+                fallacies=[],
+                children=[],
+            )
+        )
+    return children
+
+
+@app.post("/api/tree/generate", response_model=NodeSchema)
+async def generate_tree(payload: TreeRequest) -> NodeSchema:
+    root_id = str(uuid4())
+    root = NodeSchema(
+        id=root_id,
+        text=payload.topic,
+        type="claim",
+        strength=60,
+        fallacies=[],
+        children=_generate_counter_nodes(payload.topic),
+    )
+    trees[root_id] = root
+    return root
+
+
+def _detect_fallacies(node: NodeSchema, issues: List[AuditIssue]) -> None:
+    fallacy_words = {"always": "Overgeneralization", "never": "Overgeneralization"}
+    for word, fallacy in fallacy_words.items():
+        if word in node.text.lower():
+            issues.append(
+                AuditIssue(
+                    node_id=node.id,
+                    fallacy_type=fallacy,
+                    severity=1,
+                    suggestion="Avoid absolute terms",
+                    better_sources=[],
+                )
+            )
+    for child in node.children:
+        _detect_fallacies(child, issues)
+
+
+@app.post("/api/audit", response_model=AuditResponse)
+async def audit_tree(payload: AuditRequest) -> AuditResponse:
+    tree = trees.get(payload.tree_id)
+    if not tree:
+        return AuditResponse(issues=[])
+    issues: List[AuditIssue] = []
+    _detect_fallacies(tree, issues)
+    return AuditResponse(issues=issues)
+
+
+@app.post("/api/lens", response_model=LensResponse)
+async def lens_view(payload: LensRequest) -> LensResponse:
+    perspectives: List[LensPerspective] = []
+    for lens in payload.lens:
+        perspectives.append(
+            LensPerspective(
+                lens=lens,
+                counters=[f"From a {lens} perspective, {payload.claim} may be flawed."],
+            )
+        )
+    return LensResponse(perspectives=perspectives)
+
+
+@app.post("/api/research", response_model=ResearchResponse)
+async def research(payload: ResearchRequest) -> ResearchResponse:
+    citation = Citation(
+        url=f"https://en.wikipedia.org/wiki/{payload.query.replace(' ', '_')}",
+        title=payload.query.title(),
+        tier="B",
+        confidence=0.8,
+    )
+    return ResearchResponse(citations=[citation])

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,61 @@
+from sqlalchemy import Column, Integer, String, ForeignKey, Float, Enum, JSON, Table
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import relationship
+import enum
+import uuid
+
+from .database import Base
+
+
+class NodeType(str, enum.Enum):
+    claim = "claim"
+    counter = "counter"
+    rebuttal = "rebuttal"
+    evidence = "evidence"
+
+
+class SourceTier(str, enum.Enum):
+    A = "A"
+    B = "B"
+    C = "C"
+
+
+class Project(Base):
+    __tablename__ = "projects"
+
+    id = Column(String, primary_key=True, default=lambda: str(uuid.uuid4()))
+    title = Column(String, nullable=False)
+    created_at = Column(String)
+    updated_at = Column(String)
+
+    nodes = relationship("Node", back_populates="project")
+
+
+class Node(Base):
+    __tablename__ = "nodes"
+
+    id = Column(String, primary_key=True, default=lambda: str(uuid.uuid4()))
+    project_id = Column(String, ForeignKey("projects.id"), nullable=False)
+    parent_id = Column(String, ForeignKey("nodes.id"))
+    type = Column(Enum(NodeType), nullable=False)
+    text = Column(String, nullable=False)
+    strength = Column(Integer, default=0)
+    fallacies = Column(JSON)
+    lens = Column(JSON)
+
+    project = relationship("Project", back_populates="nodes")
+    parent = relationship("Node", remote_side=[id])
+    citations = relationship("Citation", back_populates="node")
+
+
+class Citation(Base):
+    __tablename__ = "citations"
+
+    id = Column(String, primary_key=True, default=lambda: str(uuid.uuid4()))
+    node_id = Column(String, ForeignKey("nodes.id"), nullable=False)
+    url = Column(String, nullable=False)
+    title = Column(String)
+    tier = Column(Enum(SourceTier))
+    confidence = Column(Float)
+
+    node = relationship("Node", back_populates="citations")

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,0 +1,80 @@
+from typing import List, Optional
+from pydantic import BaseModel, Field
+
+
+class Citation(BaseModel):
+    url: str
+    title: Optional[str] = None
+    tier: Optional[str] = None
+    confidence: Optional[float] = None
+
+
+class Rebuttal(BaseModel):
+    summary: str
+    explanation: str
+    citations: List[Citation]
+
+
+class RebuttalRequest(BaseModel):
+    claim: str
+    lens: Optional[List[str]] = None
+
+
+class RebuttalResponse(BaseModel):
+    rebuttals: List[Rebuttal]
+
+
+class NodeSchema(BaseModel):
+    id: str
+    text: str
+    type: str
+    strength: int
+    fallacies: List[str] = Field(default_factory=list)
+    children: List["NodeSchema"] = Field(default_factory=list)
+
+
+NodeSchema.update_forward_refs()
+
+
+class TreeRequest(BaseModel):
+    topic: str
+    depth: Optional[int] = 1
+    lens: Optional[List[str]] = None
+
+
+class AuditIssue(BaseModel):
+    node_id: str
+    fallacy_type: str
+    severity: int
+    suggestion: str
+    better_sources: List[str]
+
+
+class AuditRequest(BaseModel):
+    tree_id: str
+
+
+class AuditResponse(BaseModel):
+    issues: List[AuditIssue]
+
+
+class LensRequest(BaseModel):
+    claim: str
+    lens: List[str]
+
+
+class LensPerspective(BaseModel):
+    lens: str
+    counters: List[str]
+
+
+class LensResponse(BaseModel):
+    perspectives: List[LensPerspective]
+
+
+class ResearchRequest(BaseModel):
+    query: str
+
+
+class ResearchResponse(BaseModel):
+    citations: List[Citation]

--- a/docs/AEGIS_SPEC.md
+++ b/docs/AEGIS_SPEC.md
@@ -1,0 +1,316 @@
+# Aegis — Developer-Ready Product Specification
+
+*AI Debate & Idea-Mapping Platform*
+
+---
+
+## 1. Overview
+
+Aegis is an **AI-powered debate and idea-mapping platform**.
+It **auto-maps arguments**, **hunts blind spots**, **detects logical flaws**, and **provides instant rebuttals** with credible citations.
+Designed for **live debates**, **philosophical discussions**, and **research synthesis**.
+
+---
+
+## 2. Tech Stack Recommendation
+
+### Frontend
+
+* Framework: **React + Next.js** (SEO + SSR + API routes)
+* State: **Redux Toolkit** or **Zustand**
+* Visualization: **React Flow** (for argument trees) + **D3.js** (ranking/fallacy overlays)
+* Styling: **TailwindCSS** + **shadcn/ui**
+* Realtime: **WebSockets** via **Socket.IO** or **Supabase Realtime**
+
+### Backend
+
+* Framework: **FastAPI** (Python) or **Node.js + Express**
+* Auth: **Clerk** or **Supabase Auth**
+* DB: **PostgreSQL** + **pgvector** (for embeddings)
+* File Storage: **S3** (user PDFs, research notes)
+* RAG: **Pinecone** or **Weaviate** (vector DB)
+
+### AI Layer
+
+* Primary model: **GPT-4.1** or **Claude 3 Opus**
+* Local caching model: **LLaMA 3 70B** (for fast rebuttals)
+* Embeddings: **OpenAI text-embedding-3-large**
+* Fallacy detection: Custom fine-tuned **LLM classification head** (binary + multi-label)
+
+---
+
+## 3. Core Features
+
+### 3.1 Live Debate Notebook (High Priority)
+
+**Goal:** Instant rebuttals (<5s) for live debates.
+
+**Flow:**
+
+1. User inputs **opponent’s claim**.
+2. AI fetches **Top 3 strongest counters** ranked by:
+   * Argument strength
+   * Citation quality
+   * Consensus score
+3. Returns:
+   * One-liner rebuttal (≤250 chars)
+   * Expanded explanation
+   * 1–3 citations w/ source tier badge
+
+**API Endpoint:**
+
+```
+POST /api/rebuttal
+Body: { claim: string, lens?: string[] }
+Returns: {
+  rebuttals: [{
+    summary: string,
+    explanation: string,
+    citations: [{ url, title, tier, confidence }]
+  }]
+}
+```
+
+**Acceptance Criteria**
+
+* Response latency ≤5s for rebuttals.
+* Each rebuttal has ≥1 citation with 80%+ confidence.
+* Summary is concise + logically sound.
+
+---
+
+### 3.2 Argument Tree Builder
+
+**Goal:** Visualize complete reasoning flow.
+
+**Features:**
+
+* Auto-expanding argument trees:
+  * Claim → Counter → Rebuttal → Evidence.
+* Nodes have badges:
+  * **Type:** Claim / Counter / Rebuttal / Evidence
+  * **Strength Score:** 0–100
+  * **Fallacy Flags:** [“Strawman”, “Circularity”]
+  * **Lens Tags:** e.g., “Utilitarian”, “Nietzschean”
+
+**Library:**
+Use **React Flow** for zoomable, interactive trees.
+
+**API Endpoint:**
+
+```
+POST /api/tree/generate
+Body: { topic: string, depth?: number, lens?: string[] }
+Returns: {
+  root: { id, text, type, strength, fallacies[], children[] }
+}
+```
+
+**Acceptance Criteria**
+
+* Tree autogenerates ≥3 counters per claim.
+* Clicking a node expands counters dynamically.
+* Fallacy flags are auto-generated where detected.
+
+---
+
+### 3.3 Adversarial Audit (Always Hard Mode)
+
+**Goal:** Stress-test reasoning and find weaknesses.
+
+**Features:**
+
+* “Run Audit” button evaluates entire tree:
+  * Detects contradictions between nodes.
+  * Flags logical fallacies.
+  * Suggests stronger framing + better sources.
+
+**API Endpoint:**
+
+```
+POST /api/audit
+Body: { tree_id: string }
+Returns: {
+  issues: [{
+    node_id,
+    fallacy_type,
+    severity: 1|2|3,
+    suggestion,
+    better_sources[]
+  }]
+}
+```
+
+**Fallacy Taxonomy** (v1):
+
+* Ad Hominem
+* Strawman
+* Circular Reasoning
+* Slippery Slope
+* False Cause
+* Appeal to Authority
+* False Equivalence
+
+**Acceptance Criteria**
+
+* ≥80% precision on internal fallacy test set.
+* ≥3 weaknesses flagged per branch (avg).
+
+---
+
+### 3.4 Multi-Persona Lenses
+
+**Goal:** Simulate different philosophical/disciplinary viewpoints.
+
+**Features:**
+
+* Prebuilt lenses:
+  * **Philosophy:** Utilitarian, Kantian, Nietzschean, Existentialist.
+  * **Scientific:** Empirical, Bayesian.
+  * **Legal/Economic:** Policy, Market.
+* User can toggle multiple lenses to generate parallel branches.
+
+**API Endpoint:**
+
+```
+POST /api/lens
+Body: { claim: string, lens: string[] }
+Returns: { perspectives: [{lens, counters[]}] }
+```
+
+---
+
+### 3.5 Research & Citations
+
+**Goal:** Back every rebuttal with credible, relevant sources.
+
+**Features:**
+
+* RAG pipeline:
+  * Step 1: Embed claim/query.
+  * Step 2: Search vector DB + live web.
+  * Step 3: Rank results → filter low-quality sources.
+* Citation tiers:
+  * **Tier A:** Peer-reviewed, official reports.
+  * **Tier B:** Reputable media, think tanks.
+  * **Tier C:** Blogs/forums (only if no better source).
+
+**API Endpoint:**
+
+```
+POST /api/research
+Body: { query: string }
+Returns: { citations: [{url, title, snippet, tier, confidence}] }
+```
+
+---
+
+## 4. Data Model (Database Schema)
+
+### projects
+
+| Column      | Type      | Description   |
+| ----------- | --------- | ------------- |
+| id          | UUID      | Primary key   |
+| title       | TEXT      | Project title |
+| created_at | TIMESTAMP |               |
+| updated_at | TIMESTAMP |               |
+
+### nodes
+
+| Column      | Type                                     | Description         |
+| ----------- | ---------------------------------------- | ------------------- |
+| id          | UUID                                     | Primary key         |
+| project_id | UUID                                     | FK → projects       |
+| parent_id  | UUID                                     | Self-ref            |
+| type        | ENUM(claim, counter, rebuttal, evidence) |                     |
+| text        | TEXT                                     | Content             |
+| strength    | INT                                      | 0–100               |
+| fallacies   | JSONB                                    | [{type, severity}] |
+| lens        | TEXT[]                                  | Active perspectives |
+
+### citations
+
+| Column     | Type        | Description    |
+| ---------- | ----------- | -------------- |
+| id         | UUID        | PK             |
+| node_id   | UUID        | FK → nodes     |
+| url        | TEXT        | Source URL     |
+| tier       | ENUM(A,B,C) | Source quality |
+| confidence | FLOAT       | 0–1            |
+
+---
+
+## 5. Frontend UX Flows
+
+### 5.1 Notebook Mode
+
+* Left: Input box for opponent claim.
+* Middle: Top 3 counters (one-liners).
+* Right: Sources panel + “Copy Rebuttal” button.
+
+### 5.2 Argument Tree
+
+* Interactive canvas (React Flow):
+  * Zoomable.
+  * Click → expand counters/rebuttals.
+  * Hover → strength + fallacy badges.
+  * Toggle lenses → overlay new branches.
+
+### 5.3 Audit Panel
+
+* List of flagged weaknesses.
+* “Suggested Fix” buttons auto-reframe node text.
+* Better sources appear inline.
+
+---
+
+## 6. AI Model Strategy
+
+* **Prompting:**
+  * Role: *“You are an elite adversarial debate opponent.”*
+  * Rules:
+    1. Always break flawed reasoning.
+    2. Generate strongest counters ranked by robustness.
+    3. Cite verifiable sources inline.
+    4. Output in structured JSON for frontend parsing.
+* **RAG:**
+  * Use embeddings to pull relevant PDFs + web data.
+* **Ranking Logic:**
+
+```
+strength = 0.5*(source_quality) +
+           0.3*(consensus_score) +
+           0.2*(logical_cohesion)
+```
+
+---
+
+## 7. Non-Functional Requirements
+
+* **Performance:** Notebook rebuttal ≤5s median, ≤10s P95.
+* **Security:** JWT auth; encrypted uploads.
+* **Scalability:** Horizontally scalable WebSocket infra.
+* **Privacy:** No data used for model training unless user opts in.
+
+---
+
+## 8. Milestones
+
+### Phase 1 (Weeks 1–4)
+
+* Notebook MVP + Top 3 rebuttals + citations.
+* Basic tree view (manual + auto-branch v0).
+
+### Phase 2 (Weeks 5–8)
+
+* Full auto-branching + strength scoring.
+* Adversarial audit panel.
+* Lenses for 4 philosophical perspectives.
+
+### Phase 3 (Weeks 9–12)
+
+* Export trees (PDF/Markdown).
+* Optimized citation RAG + source tiering.
+* Focus mode + hotkeys.
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+fastapi
+uvicorn
+sqlalchemy
+pydantic
+pytest
+httpx

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,42 @@
+from fastapi.testclient import TestClient
+from app.main import app
+
+client = TestClient(app)
+
+
+def test_rebuttal():
+    response = client.post("/api/rebuttal", json={"claim": "Cats are great"})
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["rebuttals"]) == 3
+    assert all("citations" in r for r in data["rebuttals"])
+
+
+def test_tree_and_audit():
+    # Generate a tree with an absolute term to trigger audit issue
+    response = client.post("/api/tree/generate", json={"topic": "Cats always win"})
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["children"]) == 3
+    tree_id = data["id"]
+
+    audit_resp = client.post("/api/audit", json={"tree_id": tree_id})
+    assert audit_resp.status_code == 200
+    issues = audit_resp.json()["issues"]
+    assert len(issues) >= 1
+
+
+def test_lens():
+    response = client.post(
+        "/api/lens", json={"claim": "Test", "lens": ["Utilitarian"]}
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["perspectives"][0]["lens"] == "Utilitarian"
+
+
+def test_research():
+    response = client.post("/api/research", json={"query": "Cats"})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["citations"][0]["url"].startswith("https://")


### PR DESCRIPTION
## Summary
- implement dynamic rebuttals, tree generation, audit detection, lens perspectives, and research citations using in-memory data
- fix schema list defaults to use `Field(default_factory=list)` for safe instantiation
- expand tests to cover new functionality

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4c2d3d3588332a149c21f651cbc22